### PR TITLE
Use d notated cmdline arg strings

### DIFF
--- a/chancetoroll/notation.py
+++ b/chancetoroll/notation.py
@@ -1,0 +1,19 @@
+from typing import List, Tuple
+
+
+def parse_dstr(dstr: str) -> Tuple[int, int]:
+    """
+    Parse a d notated string (e.g. 3d6, 1d20), and return a tuple of ints
+    representing the number and type of dice to roll.
+    """
+    num: int
+    dice_type: int
+    parsed_dstr: List = dstr.strip().split('d')
+
+    if len(parsed_dstr) > 2:
+        raise Exception("d notated string contains not readable")
+
+    num = int(parsed_dstr[0])
+    dice_type = int(parsed_dstr[1])
+
+    return num, dice_type

--- a/chancetoroll/out.py
+++ b/chancetoroll/out.py
@@ -1,0 +1,9 @@
+
+
+def print_success_prob(
+    typedice: int, numdice: int, targetside: int, probability: float
+) -> None:
+    print(
+        f"Rolling {numdice}d{typedice}, probability of "
+        f"beating a {targetside} is {probability:.4f}"
+    )

--- a/chancetoroll/rollem.py
+++ b/chancetoroll/rollem.py
@@ -39,18 +39,3 @@ def calc_success_probability(
     probability: float = float(a)/b
 
     return probability
-
-
-def print_success_prob(
-    typedice: int, numdice: int, targetside: int
-) -> None:
-    probability = calc_success_probability(typedice, numdice, targetside)
-
-    print(
-        "Rolling {}d{}, probability of beating a {} = {}".format(
-            numdice,
-            typedice,
-            targetside,
-            probability,
-        )
-    )

--- a/chancetoroll/rollem.py
+++ b/chancetoroll/rollem.py
@@ -47,7 +47,7 @@ def print_success_prob(
     probability = calc_success_probability(typedice, numdice, targetside)
 
     print(
-        'Rolling {}d{}, probability of beating a {} = {}'.format(
+        "Rolling {}d{}, probability of beating a {} = {}".format(
             numdice,
             typedice,
             targetside,

--- a/chancetoroll/run.py
+++ b/chancetoroll/run.py
@@ -3,7 +3,8 @@
 import argparse
 
 from notation import parse_dstr
-from rollem import print_success_prob
+from out import print_success_prob
+from rollem import calc_success_probability
 
 
 def main() -> None:
@@ -36,7 +37,11 @@ def main() -> None:
     dice_type: int
     num, dice_type = parse_dstr(args.dice)
 
-    print_success_prob(dice_type, num, args.targetside)
+    probability: float = calc_success_probability(
+        dice_type, num, args.targetside
+    )
+
+    print_success_prob(dice_type, num, args.targetside, probability)
 
 
 if __name__ == "__main__":

--- a/chancetoroll/run.py
+++ b/chancetoroll/run.py
@@ -2,49 +2,42 @@
 
 import argparse
 
+from notation import parse_dstr
 from rollem import print_success_prob
 
 
 def main() -> None:
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description=(
-            'Determine the probability of rolling '
-            'x or greater on n individual dice.'
+            "Determine the probability of rolling "
+            "x or greater on n individual dice."
         )
     )
     parser.add_argument(
-        'typedice',
-        type=int,
+        "dice",
+        type=str,
         help=(
-            'The type of dice to roll '
-            '(4 = d4, 6 = d6, 20 = d20, etc.)'
+            "The number and type of dice to roll "
+            "(e.g. 3d6 is three six-sided dice, 1d20 is one twenty-sided dice)"
         )
     )
     parser.add_argument(
-        'numdice',
+        "targetside",
         type=int,
         help=(
-            'The number of dice to roll '
-            '(1 = roll 1 dice, 2 = roll 2 dice, etc.)'
-        )
-    )
-    parser.add_argument(
-        'targetside',
-        type=int,
-        help=(
-            'The value a single dice must beat to be a success '
-            '(e.g. 5 = rolls of 5 or higher are a success)'
+            "The value a single dice must beat to be a success "
+            "(e.g. 5 = rolls of 5 or higher are a success)"
         )
     )
 
     args = parser.parse_args()
 
-    print_success_prob(
-        args.typedice,
-        args.numdice,
-        args.targetside,
-    )
+    num: int
+    dice_type: int
+    num, dice_type = parse_dstr(args.dice)
+
+    print_success_prob(dice_type, num, args.targetside)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
It's a common convention to use what I'm calling "d formatted strings" to reference groups of dice in tabletop rpgs (e.g. 3d6 is three six-sided dice, 1d20 is one twenty-sided dice, 2d10 is 2 ten-sided dice). I'm updating the args to support this format in lieu of the former individual args.