### PR TITLE
Add tests of notation dstr parser

### DIFF
--- a/chancetoroll/notation.py
+++ b/chancetoroll/notation.py
@@ -8,7 +8,7 @@ def parse_dstr(dstr: str) -> Tuple[int, int]:
     """
     num: int
     dice_type: int
-    parsed_dstr: List = dstr.strip().split('d')
+    parsed_dstr: List = dstr.strip().split("d")
 
     if len(parsed_dstr) > 2:
         raise Exception("d notated string contains not readable")

--- a/tests/test_notation.py
+++ b/tests/test_notation.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from chancetoroll import notation
+
+
+class TestParseDstr(TestCase):
+    def test_3d6(self):
+        self.assertEqual(notation.parse_dstr("3d6"), (3, 6))
+
+    def test_1d20(self):
+        self.assertEqual(notation.parse_dstr("1d20"), (1, 20))
+
+    def test_4d8(self):
+        self.assertEqual(notation.parse_dstr("4d8"), (4, 8))
+
+    def test_bad_str(self):
+        with self.assertRaises(IndexError):
+            notation.parse_dstr("123")
+
+    def test_partial_str(self):
+        with self.assertRaises(ValueError):
+            notation.parse_dstr("2d")


### PR DESCRIPTION
This change adds some tests of `chancetoroll.notation.parse_dstr`